### PR TITLE
Added empty `assets/js`, `assets/css`, `assets/wasm` directories to codebase

### DIFF
--- a/assets/css/.gitignore
+++ b/assets/css/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/assets/js/.gitignore
+++ b/assets/js/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/assets/wasm/.gitignore
+++ b/assets/wasm/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
As mentioned in the [comment](https://github.com/navionguy/basicwasm/pull/4#issuecomment-1925884862), the build process (e.g. "from scratch") also requires the `assets/js`, `assets/css`, `assets/wasm` directories to exist.

Added these empty directories to codebase using `.gitignore` approach adviced [here](https://stackoverflow.com/a/932982).

If this approach is not suitable to this project, please suggest which solution to implement, and I'll try to change this PR to alternative approach.